### PR TITLE
Fix error in clunit_name definition

### DIFF
--- a/voice/festvox/lvl_is_v0_clunits.scm
+++ b/voice/festvox/lvl_is_v0_clunits.scm
@@ -175,10 +175,10 @@ plus previous phone (or something else)."
 		    (string-equal "pau" (item.feat i "n.name")))))
       "ignore")
 
-     (string-append
-       (item.name i)
+     (t (string-append
+       name
        "_"
-       (item.feat i "p.name")
+       (item.feat i "p.name"))
      )
 )))
 

--- a/voice/festvox/lvl_is_v0_clunits.scm
+++ b/voice/festvox/lvl_is_v0_clunits.scm
@@ -175,6 +175,15 @@ plus previous phone (or something else)."
 		    (string-equal "pau" (item.feat i "n.name")))))
       "ignore")
 
+     ((and (string-equal "pau" name)
+        (string-equal "pau" (item.feat i "p.name")))
+      (string-append
+        name
+        "_"
+        (item.feat i "p.name")
+        "_"
+        (item.feat i "n.name")))
+
      (t (string-append
        name
        "_"


### PR DESCRIPTION
The diphone names weren't being used due to an error in lvl_is_v0_clunits.scm. This caused unit distance tables to become extremely large, creating a bottleneck (which seemed infinite). This pull request should fix that error. We might want to experiment with a couple of different setups for these clunit names.